### PR TITLE
Update next example to use the latest client library

### DIFF
--- a/examples/conversational-ai/nextjs/package.json
+++ b/examples/conversational-ai/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@11labs/client": "0.0.1",
+    "@11labs/client": "latest",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
next example was using the oldest possible version of the client lib, now it matches the javascript example