### PR TITLE
Fix broken WebSocket handler for outbound media stream

### DIFF
--- a/examples/conversational-ai/twilio/javascript/outbound.js
+++ b/examples/conversational-ai/twilio/javascript/outbound.js
@@ -124,8 +124,9 @@ fastify.register(async fastifyInstance => {
   fastifyInstance.get(
     "/outbound-media-stream",
     { websocket: true },
-    (ws, req) => {
+    (connection, req) => {
       console.info("[Server] Twilio connected to outbound media stream");
+      const ws = connection.socket;
 
       // Variables to track the call
       let streamSid = null;


### PR DESCRIPTION
Fixed an issue where the `/outbound-media-stream` WebSocket route wasn't working due to incorrect parameter usage.

Fastify provides the `connection` object in WebSocket routes, not the raw `ws` socket. This update correctly accesses the WebSocket via `connection.socket`, restoring proper behavior for Twilio's media stream connection.

**Changes:**
- Replaced `(ws, req)` with `(connection, req)` in WebSocket route handler
- Added const `ws = connection.socket` to maintain compatibility with existing logic

