### PR TITLE
Remove deprecated MutableObject

### DIFF
--- a/agents/nextjs/quickstart/example/app/page.tsx
+++ b/agents/nextjs/quickstart/example/app/page.tsx
@@ -6,7 +6,7 @@ import {
   useConversationStatus,
 } from "@elevenlabs/react";
 import {
-  type MutableRefObject,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -37,7 +37,7 @@ type VoiceAgentPageProps = {
   setSessionError: (value: string | null) => void;
   setStarting: (value: boolean) => void;
   starting: boolean;
-  nextLineId: MutableRefObject<number>;
+  nextLineId: RefObject<number>;
 };
 
 type ConversationMessage = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only change in a Next.js example: updates the `nextLineId` ref prop typing to be less permissive, with minimal runtime risk.
> 
> **Overview**
> Updates the Next.js voice agent quickstart example to use `RefObject<number>` instead of `MutableRefObject<number>` for the `nextLineId` ref prop, removing the `MutableRefObject` import and tightening the ref typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fc4bb1c1802896a975a4b6d4b6c4d10cf7256a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->