### PR TITLE
fix: bump postcss to 8.5.12 (CVE-2026-45623)

### DIFF
--- a/agents/nextjs/guardrails/example/package.json
+++ b/agents/nextjs/guardrails/example/package.json
@@ -36,5 +36,8 @@
     "overrides": {
       "livekit-client": "2.19.1"
     }
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/agents/nextjs/quickstart/example/package.json
+++ b/agents/nextjs/quickstart/example/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.43.0",
+    "@elevenlabs/react": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,9 +18,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/react": "^1.1.0",
-    "@elevenlabs/elevenlabs-js": "^2.43.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -36,5 +36,8 @@
     "overrides": {
       "livekit-client": "2.16.1"
     }
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/dubbing/nextjs/quickstart/example/package.json
+++ b/dubbing/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/music/nextjs/quickstart/example/package.json
+++ b/music/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/sound-effects/nextjs/quickstart/example/package.json
+++ b/sound-effects/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/speech-engine/nextjs/quickstart/example/package.json
+++ b/speech-engine/nextjs/quickstart/example/package.json
@@ -12,18 +12,18 @@
     "speech-engine:server": "tsx server.mts"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.49.1",
+    "@elevenlabs/react": "^1.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dotenv": "^17.4.2",
     "lucide-react": "^0.575.0",
     "next": "16.2.6",
+    "openai": "^6.38.0",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/react": "^1.6.2",
-    "@elevenlabs/elevenlabs-js": "^2.49.1",
-    "openai": "^6.38.0",
-    "dotenv": "^17.4.2"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -34,13 +34,16 @@
     "eslint-config-next": "16.1.6",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
+    "tsx": "^4.22.3",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
-    "tsx": "^4.22.3"
+    "typescript": "^5"
   },
   "pnpm": {
     "overrides": {
       "livekit-client": "2.16.1"
     }
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/speech-to-text/nextjs/realtime/example/package.json
+++ b/speech-to-text/nextjs/realtime/example/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.37.0",
+    "@elevenlabs/react": "^0.14.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,9 +18,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/react": "^0.14.1",
-    "@elevenlabs/elevenlabs-js": "^2.37.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -31,5 +31,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -29,5 +29,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/text-to-speech/nextjs/quickstart/example/package.json
+++ b/text-to-speech/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/voice-changer/nextjs/quickstart/example/package.json
+++ b/voice-changer/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }

--- a/voice-isolator/nextjs/quickstart/example/package.json
+++ b/voice-isolator/nextjs/quickstart/example/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@elevenlabs/elevenlabs-js": "^2.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -16,8 +17,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0",
-    "@elevenlabs/elevenlabs-js": "^2.40.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -30,5 +30,8 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.12"
   }
 }


### PR DESCRIPTION
## Security fix: CVE-2026-45623

Bumps `postcss` to `8.5.12` to resolve CVE-2026-45623. This closes 44 Wiz-tracked issue(s).

**Rationale for this fix:** Step 2 (scoped to REPOSITORY_BRANCH/CODE assets, status=OPEN, has_fix=true, ordered by RESOURCE_COUNT desc) ranked GHSA-r28c-9q8g-f849 first (46 findings) but that is excluded per the in-progress list. Among remaining candidates, CVE-2026-45623 (postcss arbitrary file read via sourceMappingURL, HIGH 7.5) ranked #1 with 44 findings across 16 distinct GitHub repos/branches, ahead of CVE-2026-41305 (41 findings, also postcss but a different XSS bug) and a cluster of Next.js CVE-2026-646xx issues (30 findings/13 assets each). Effort assessment: CVE-2026-45623 is LOW effort — every one of the 44 findings names the exact same single package (postcss) and the exact same single fixed version (8.5.12) both in the catalog record and in every individual finding, with no conflicting or ambiguous fix targets. By contrast CVE-2026-41305's findings showed inconsistent/ambiguous fixedVersion values (8.5.10 for some, a 'next@16.3.0-canary.6' value for transitive findings, and null for at least one finding), making it a messier, higher-effort fix to reconcile; the Next.js CVE-2026-646xx cluster would each only need a minor Next.js bump too but affects fewer resources (30 vs 44) and splitting effort across three separate CVEs is less efficient than one consolidated postcss bump. Because CVE-2026-45623 is simultaneously the highest-impact non-excluded candidate (44 findings/16 repos) AND clearly LOW-effort (single package, single semver-patch fix version, satisfiable via a direct/override dependency bump with no breaking API changes noted in the advisory), there is no impact-vs-effort tradeoff to make, so it is selected outright per the guidance to not sacrifice impact when effort is already low. Ecosystem is npm (JavaScript/Node package manager), consistent with Wiz's own classification (npm GitHub Advisory feed, package-lock.json/pnpm-lock.yaml/package.json manifests observed in findings).

### Patch stage results
- Test command used: `npm install && npm ls postcss (to confirm resolved version) && npm run build (next build) — run in each of the 11 affected example dirs (templates/nextjs, text-to-speech/nextjs/quickstart/example, agents/nextjs/quickstart/example, agents/nextjs/guardrails/example, sound-effects/nextjs/quickstart/example, voice-changer/nextjs/quickstart/example, speech-engine/nextjs/quickstart/example, dubbing/nextjs/quickstart/example, music/nextjs/quickstart/example, voice-isolator/nextjs/quickstart/example, speech-to-text/nextjs/realtime/example)`
- Build passed: True
- Tests passed: True
- Vulnerability resolved: True
- Major version bump: False
- Notes: This is a monorepo of independent example apps with no per-example lockfiles committed (root .gitignore explicitly ignores nested package-lock.json files, only the root one is tracked). postcss is not a direct dependency anywhere; it's pulled in transitively (pinned to exact version 8.4.31) by 'next' (and re-required by @tailwindcss/postcss and shadcn) across the 11 Next.js example package.json manifests. Since there's no lockfile to bump and hand-editing a lockfile is disallowed, I used the proper npm tooling `npm pkg set overrides.postcss=8.5.12` on each of the 11 affected package.json files to force npm's dependency resolver to pin the transitive postcss to the fixed version (npm's standard mechanism for pinning a transitive dependency). For each example I then ran `npm install` and verified via `npm ls postcss` that the resolved/overridden version is 8.5.12 everywhere (previously 8.4.31), and ran `npm run build` (next build) in every one of the 11 examples — all built successfully with Turbopack, confirming no regression. There is no repo-wide CI test suite for these examples (the only CI workflow, .github/workflows/lint.yml, just runs ruff and prettier checks against the repo root, not per-example builds/tests), so `next build` per example was the most meaningful functional verification available, and I applied it to every affected example rather than just one. Generated node_modules/, package-lock.json, and .next build artifacts were removed after verification since they are gitignored in this repo and should not be committed. The final diff touches only the 11 package.json files, each adding an `overrides.postcss = "8.5.12"` entry (npm's package.json writer also reflowed a few pre-existing dependency keys alphabetically in some files as a harmless side effect of using `npm pkg set`, with no semantic change). 8.5.12 is a patch-level bump within the postcss 8.x line, so this is not a major/breaking version bump.

### Independent verification results
- Regressions found: False
- Confidence: medium
- Recommendation: proceed
- Findings:
- Patch applies cleanly to a fresh checkout (git apply --check and git apply both exit 0).
- Diff scope confirmed minimal: only the 11 Next.js package.json files change; no source/config files touched. Intra-file dependency reorderings are alphabetical (side effect of `npm pkg set`) and semantically neutral.
- All 11 manifests now contain overrides.postcss = "8.5.12"; postcss is transitive everywhere (no direct dependency/devDependency on postcss in any manifest).
- Independently installed templates/nextjs: `npm ls postcss` shows postcss@8.5.12 'overridden' and node_modules/postcss is version 8.5.12 (>= fixed 8.5.12). `npm run build` (next build 16.1.6, Turbopack) succeeded.
- Independently installed agents/nextjs/quickstart/example (which also has a coexisting pnpm.overrides block): resolved postcss@8.5.12 and `npm run build` succeeded, confirming npm still honors the top-level overrides alongside pnpm.overrides.
- CI concern checked: the only CI workflow runs `npx prettier . --check`. Ran prettier@3.8.1 --check on all changed files -> 'All matched files use Prettier code style', so the JSON edits do not break the prettier CI gate.
- Only 2 of 11 examples were built end-to-end (chosen to cover both the plain pattern and the pnpm.overrides-coexisting pattern); the remaining 9 use the identical override mechanism and were not individually built.
- Caveat (not a regression under current toolchain): 3 examples (agents/guardrails, agents/quickstart, speech-engine) declare pnpm.overrides. The fix uses npm-style `overrides`; a pnpm-based install of those would not pin postcss. No committed per-example lockfiles exist and CI uses npm, so the fix is effective for the actual toolchain.

---
🤖 Opened automatically by the CVE patch orchestrator. This PR is a draft pending human review — it will not be marked ready for review automatically.
