### PR TITLE
Remove redundant livekit-client pnpm override

### DIFF
--- a/.cursor/skills/scaffold-elevenlabs-example/reference.md
+++ b/.cursor/skills/scaffold-elevenlabs-example/reference.md
@@ -53,7 +53,7 @@ Ignore the deprecated root `examples/` folder for new work.
 | `speech-to-text/nextjs/realtime`       | `templates/nextjs`     | `app/api/scribe-token/route.ts`, `app/page.tsx`                                                         | Adds `@elevenlabs/react` and `@elevenlabs/elevenlabs-js`, copies `.env.local`, preserves `node_modules` and `.next` |
 | `agents/nextjs/quickstart`             | `templates/nextjs`     | `app/api/agent/route.ts`, `app/api/conversation-token/route.ts`, `app/page.tsx`                         | Same Next.js setup pattern, removes `@elevenlabs/client` if present                                                 |
 | `agents/nextjs/guardrails`             | `templates/nextjs`     | `app/api/agent/route.ts`, `app/api/conversation-token/route.ts`, `app/page.tsx`                         | Same as quickstart, but prompt targets guardrails and `onGuardrailTriggered`                                        |
-| `speech-engine/nextjs/quickstart`      | `templates/nextjs`     | `server.mts`, `scripts/create-engine.mts`, `app/api/token/route.ts`, `app/page.tsx`, `lib/assistant.ts` | Adds `openai`, `dotenv`, `tsx`; Speech Engine scripts; `livekit-client` override; copies `.env.example`             |
+| `speech-engine/nextjs/quickstart`      | `templates/nextjs`     | `server.mts`, `scripts/create-engine.mts`, `app/api/token/route.ts`, `app/page.tsx`, `lib/assistant.ts` | Adds `openai`, `dotenv`, `tsx`; Speech Engine scripts; copies `.env.example`                                        |
 
 ## Runtime setup rules
 

--- a/agents/expo/quickstart/example/package.json
+++ b/agents/expo/quickstart/example/package.json
@@ -25,17 +25,12 @@
     "react-native-safe-area-context": "latest",
     "react-native-screens": "latest",
     "react-native-web": "latest",
-    "@elevenlabs/react": "^1.1.1",
-    "@elevenlabs/elevenlabs-js": "^2.43.0"
+    "@elevenlabs/react": "^1.12.0",
+    "@elevenlabs/elevenlabs-js": "^2.60.0"
   },
   "devDependencies": {
     "@types/react": "latest",
     "babel-plugin-module-resolver": "latest",
     "typescript": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "livekit-client": "2.16.1"
-    }
   }
 }

--- a/agents/expo/quickstart/setup.sh
+++ b/agents/expo/quickstart/setup.sh
@@ -31,9 +31,6 @@ node -e "
   pkg.name = 'realtime-voice-agent-expo';
   pkg.dependencies['@elevenlabs/react'] = '^' + process.env.REACT_VER;
   pkg.dependencies['@elevenlabs/elevenlabs-js'] = '^' + process.env.ELEVENLABS_VER;
-  pkg.pnpm = pkg.pnpm || {};
-  pkg.pnpm.overrides = pkg.pnpm.overrides || {};
-  pkg.pnpm.overrides['livekit-client'] = '2.16.1';
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
   app.expo.name = 'Real-Time Voice Agent';
   app.expo.slug = 'realtime-voice-agent-expo';

--- a/agents/nextjs/guardrails/example/package.json
+++ b/agents/nextjs/guardrails/example/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@elevenlabs/elevenlabs-js": "^2.51.0",
-    "@elevenlabs/react": "^1.6.4",
+    "@elevenlabs/elevenlabs-js": "^2.60.0",
+    "@elevenlabs/react": "^1.12.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
@@ -31,10 +31,5 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "livekit-client": "2.16.1"
-    }
   }
 }

--- a/agents/nextjs/guardrails/setup.sh
+++ b/agents/nextjs/guardrails/setup.sh
@@ -33,9 +33,6 @@ node -e "
   pkg.dependencies['@elevenlabs/react'] = '^' + process.env.REACT_VER;
   pkg.dependencies['@elevenlabs/elevenlabs-js'] = '^' + process.env.ELEVENLABS_VER;
   delete pkg.dependencies['@elevenlabs/client'];
-  pkg.pnpm = pkg.pnpm || {};
-  pkg.pnpm.overrides = pkg.pnpm.overrides || {};
-  pkg.pnpm.overrides['livekit-client'] = '2.16.1';
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 

--- a/agents/nextjs/quickstart/example/package.json
+++ b/agents/nextjs/quickstart/example/package.json
@@ -17,8 +17,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.5.0",
-    "@elevenlabs/react": "^1.1.0",
-    "@elevenlabs/elevenlabs-js": "^2.43.0"
+    "@elevenlabs/react": "^1.12.0",
+    "@elevenlabs/elevenlabs-js": "^2.60.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -31,10 +31,5 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
-  },
-  "pnpm": {
-    "overrides": {
-      "livekit-client": "2.16.1"
-    }
   }
 }

--- a/agents/nextjs/quickstart/setup.sh
+++ b/agents/nextjs/quickstart/setup.sh
@@ -31,9 +31,6 @@ node -e "
   pkg.dependencies['@elevenlabs/react'] = '^' + process.env.REACT_VER;
   pkg.dependencies['@elevenlabs/elevenlabs-js'] = '^' + process.env.ELEVENLABS_VER;
   delete pkg.dependencies['@elevenlabs/client'];
-  pkg.pnpm = pkg.pnpm || {};
-  pkg.pnpm.overrides = pkg.pnpm.overrides || {};
-  pkg.pnpm.overrides['livekit-client'] = '2.16.1';
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 

--- a/speech-engine/nextjs/quickstart/PROMPT.md
+++ b/speech-engine/nextjs/quickstart/PROMPT.md
@@ -4,7 +4,6 @@ Before writing any code, invoke the `/speech-engine` skill to learn the correct 
 
 - Add `@elevenlabs/react`, `@elevenlabs/elevenlabs-js`, `openai`, `dotenv`, and `tsx`.
 - Add scripts: `speech-engine:create` (`tsx scripts/create-engine.mts`), `speech-engine:enable-first-message` (`tsx scripts/enable-first-message.mts`), `speech-engine:server` (`tsx server.mts`).
-- Pin `livekit-client` to `2.16.1` under `pnpm.overrides` for WebRTC stability.
 
 ## 2. `.env.example`
 

--- a/speech-engine/nextjs/quickstart/example/package.json
+++ b/speech-engine/nextjs/quickstart/example/package.json
@@ -20,9 +20,9 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.5.0",
-    "@elevenlabs/react": "^1.6.2",
-    "@elevenlabs/elevenlabs-js": "^2.49.1",
-    "openai": "^6.38.0",
+    "@elevenlabs/react": "^1.12.0",
+    "@elevenlabs/elevenlabs-js": "^2.60.0",
+    "openai": "^7.3.0",
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
@@ -36,11 +36,6 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
-    "tsx": "^4.22.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "livekit-client": "2.16.1"
-    }
+    "tsx": "^4.23.5"
   }
 }

--- a/speech-engine/nextjs/quickstart/setup.sh
+++ b/speech-engine/nextjs/quickstart/setup.sh
@@ -42,9 +42,6 @@ node -e "
   pkg.scripts['speech-engine:create'] = 'tsx scripts/create-engine.mts';
   pkg.scripts['speech-engine:enable-first-message'] = 'tsx scripts/enable-first-message.mts';
   pkg.scripts['speech-engine:server'] = 'tsx server.mts';
-  pkg.pnpm = pkg.pnpm || {};
-  pkg.pnpm.overrides = pkg.pnpm.overrides || {};
-  pkg.pnpm.overrides['livekit-client'] = '2.16.1';
   require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 


### PR DESCRIPTION
## Summary

Four examples pinned `livekit-client` to `2.16.1` under `pnpm.overrides`. The pin is a no-op: `@elevenlabs/client@1.17.0` already depends on `livekit-client` at an **exact** `2.16.1`, not a range, so the override just restated the version the SDK forces. Removing it lets the SDK own that version instead of every example having to track it.

Verified by resolving the tree with the override gone — all four examples still install `livekit-client 2.16.1`:

```
@elevenlabs/react 1.12.0
└─┬ @elevenlabs/client 1.17.0
  └── livekit-client 2.16.1
```

The original reason for the pin is also gone server-side. `livekit.rtc.elevenlabs.io/rtc/v1/validate`, the path whose 404s motivated the pin, now answers `400 join_request is required`. That is moot while the SDK hard-pins `2.16.1`, but it means there is no longer a known-broken version to defend against.

Removed from `setup.sh` and `example/package.json` in:

- `agents/nextjs/quickstart`
- `agents/nextjs/guardrails`
- `agents/expo/quickstart`
- `speech-engine/nextjs/quickstart`

Also dropped the instruction to add the pin from `speech-engine/nextjs/quickstart/PROMPT.md` and the mention in the scaffold skill's `reference.md`, so a regeneration run does not reintroduce it.

Dependencies were re-resolved from scratch (lockfiles deleted) and the setup-managed versions bumped to current latest, matching what a fresh `setup.sh` produces: `@elevenlabs/react` 1.12.0, `@elevenlabs/elevenlabs-js` 2.60.0, plus `openai` 7.3.0 and `tsx` 4.23.5 for speech-engine.

## Test plan

Verified locally:

- [x] `next build` passes for all three Next.js examples
- [x] `tsc --noEmit` passes for the Expo example
- [x] `npx prettier . --check` and `ruff check .` both pass
- [x] `livekit-client` still resolves to `2.16.1` in all four examples
- [x] `/api/conversation-token` returns a real token in both agents examples, and those tokens validate `200 success` against `livekit.rtc.elevenlabs.io/rtc/validate`
- [x] speech-engine `/api/chat` works on the `openai` 6 → 7 major bump

Not covered:

- [ ] A real browser voice session with a microphone
- [ ] speech-engine voice path in `server.mts` — the `ELEVENLABS_SPEECH_ENGINE_ID` in my local `.env` returns 404 from the API, so that resource needs recreating before it can be exercised

Made with [Cursor](https://cursor.com)